### PR TITLE
Upgrade to Spring Boot 3.2 / Java 17 / Spring Security 6 (#4)

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -5,25 +5,38 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.9.RELEASE</version>
+		<version>3.2.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.wotos</groupId>
 	<artifactId>wotos-user-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>wotos-user-service</name>
-	<description>Demo project for Spring Boot</description>
+	<description>WoToS authentication service — JWT-based login and user management with Spring Security</description>
 
 	<properties>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<java.version>17</java.version>
+		<spring-cloud.version>2023.0.5</spring-cloud.version>
+		<jjwt.version>0.12.6</jjwt.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt</artifactId>
-			<version>0.9.1</version>
+			<artifactId>jjwt-api</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -33,11 +46,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security.oauth</groupId>
-			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.5.0.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -50,7 +58,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<version>2.1.9.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
@@ -66,9 +77,14 @@
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/wotos/wotosuserservice/filters/JwtRequestFilter.java
+++ b/src/main/java/com/wotos/wotosuserservice/filters/JwtRequestFilter.java
@@ -10,10 +10,10 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component

--- a/src/main/java/com/wotos/wotosuserservice/model/LocalUser.java
+++ b/src/main/java/com/wotos/wotosuserservice/model/LocalUser.java
@@ -1,8 +1,8 @@
 package com.wotos.wotosuserservice.model;
 
-import javax.persistence.*;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Size;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/com/wotos/wotosuserservice/security/SecurityConfig.java
+++ b/src/main/java/com/wotos/wotosuserservice/security/SecurityConfig.java
@@ -1,57 +1,54 @@
 package com.wotos.wotosuserservice.security;
 
 import com.wotos.wotosuserservice.filters.JwtRequestFilter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Spring Security 6 configuration. Replaces the removed {@code WebSecurityConfigurerAdapter}
+ * with a component-based {@link SecurityFilterChain}.
+ *
+ * <p>Authentication is wired implicitly: the global {@link AuthenticationManager} picks up the
+ * single {@code UserDetailsService} bean ({@code CustomUserDetailsService}) and the single
+ * {@code PasswordEncoder} bean ({@code Encoder}) to build a {@code DaoAuthenticationProvider}.
+ */
+@Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    @Autowired
-    private CustomUserDetailsService customUserDetailsService;
+    private final JwtRequestFilter jwtRequestFilter;
 
-    @Autowired
-    private JwtRequestFilter jwtRequestFilter;
-
-    @Autowired
-    private Encoder encoder;
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(customUserDetailsService);
-    }
-
-    @Override
-    protected void configure(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.csrf().disable().authorizeRequests()
-                .antMatchers(
-                        "/users/login",
-                        "/users/create"
-                )
-                .permitAll().anyRequest().authenticated()
-                .and().sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        httpSecurity.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
-    }
-
-    @Override
-    @Bean
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
+    public SecurityConfig(JwtRequestFilter jwtRequestFilter) {
+        this.jwtRequestFilter = jwtRequestFilter;
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return encoder;
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/users/login", "/users/create").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+        return httpSecurity.build();
+    }
+
+    /**
+     * Exposes the container-managed {@link AuthenticationManager} so {@code UserService} can
+     * authenticate login requests.
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
 }

--- a/src/main/java/com/wotos/wotosuserservice/util/JwtUtil.java
+++ b/src/main/java/com/wotos/wotosuserservice/util/JwtUtil.java
@@ -2,10 +2,12 @@ package com.wotos.wotosuserservice.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +16,11 @@ import java.util.function.Function;
 @Service
 public class JwtUtil {
 
-    private String SECRET_KEY = "String"; // generate random string
+    // TODO(#6 — Phase 3 Security Hardening): externalize this secret to config and rotate it.
+    // jjwt 0.12 enforces HS256's 256-bit (32-byte) key floor, so the placeholder must stay >= 32 bytes.
+    private static final String SECRET_KEY = "wotos-user-service-development-secret-key-change-in-phase-3";
+
+    private final SecretKey signingKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -44,13 +50,22 @@ public class JwtUtil {
     }
 
     private Claims extractAllClaims(String token) {
-        return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 
     private String createToken(Map<String, Object> claims, String subject) {
-        return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY).compact();
+        long nowMillis = System.currentTimeMillis();
+        return Jwts.builder()
+                .claims(claims)
+                .subject(subject)
+                .issuedAt(new Date(nowMillis))
+                .expiration(new Date(nowMillis + 1000 * 60 * 60 * 10))
+                .signWith(signingKey, Jwts.SIG.HS256)
+                .compact();
     }
 
 }

--- a/src/test/java/com/wotos/wotosuserservice/WotosUserServiceApplicationTests.java
+++ b/src/test/java/com/wotos/wotosuserservice/WotosUserServiceApplicationTests.java
@@ -1,16 +1,13 @@
 package com.wotos.wotosuserservice;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
-public class WotosUserServiceApplicationTests {
+class WotosUserServiceApplicationTests {
 
 	@Test
-	public void contextLoads() {
+	void contextLoads() {
 	}
 
 }

--- a/src/test/java/com/wotos/wotosuserservice/util/JwtUtilTest.java
+++ b/src/test/java/com/wotos/wotosuserservice/util/JwtUtilTest.java
@@ -1,0 +1,56 @@
+package com.wotos.wotosuserservice.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trip coverage for the jjwt 0.12 migration: a token produced by
+ * {@link JwtUtil#generateToken} must verify and parse back with the same signing key.
+ */
+class JwtUtilTest {
+
+    private final JwtUtil jwtUtil = new JwtUtil();
+
+    private UserDetails user(String username) {
+        return new User(username, "password", Collections.emptyList());
+    }
+
+    @Test
+    void generatedTokenRoundTripsToTheSameUsername() {
+        String token = jwtUtil.generateToken(user("tanker"));
+
+        assertNotNull(token);
+        assertEquals("tanker", jwtUtil.extractUsername(token));
+    }
+
+    @Test
+    void validateTokenAcceptsAFreshTokenForTheSameUser() {
+        UserDetails userDetails = user("tanker");
+        String token = jwtUtil.generateToken(userDetails);
+
+        assertTrue(jwtUtil.validateToken(token, userDetails));
+    }
+
+    @Test
+    void validateTokenRejectsADifferentUser() {
+        String token = jwtUtil.generateToken(user("tanker"));
+
+        assertFalse(jwtUtil.validateToken(token, user("intruder")));
+    }
+
+    @Test
+    void generatedTokenExpiresInTheFuture() {
+        String token = jwtUtil.generateToken(user("tanker"));
+
+        assertTrue(jwtUtil.extractExpiration(token).getTime() > System.currentTimeMillis());
+    }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,19 @@
+# Test profile — keeps the @SpringBootTest context self-contained so it loads
+# without an external MySQL, Config Server, or Eureka registry.
+
+# Use an in-memory H2 database instead of MySQL.
+spring.datasource.url=jdbc:h2:mem:wotos-user-test;DB_CLOSE_DELAY=-1;MODE=MySQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Do not contact Spring Cloud Config or require a spring.config.import in tests.
+spring.cloud.config.enabled=false
+spring.cloud.config.import-check.enabled=false
+
+# Do not register with or fetch from Eureka in tests.
+spring.cloud.discovery.enabled=false
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false


### PR DESCRIPTION
## Summary
- Spring Boot `2.1.9.RELEASE` → `3.2.12`, Spring Cloud `Greenwich.SR3` → `2023.0.5`, Java `1.8` → `17`, Maven wrapper `3.6.0` → `3.9.9`.
- Jakarta EE 9 migration (`javax` → `jakarta` for servlet / persistence / validation); JJWT `0.9.1` → `0.12.6` (api/impl/jackson split) with the new builder API and 256-bit HMAC key floor.
- Spring Security 6: `WebSecurityConfigurerAdapter` removed in favor of a component-based `SecurityFilterChain`; `AuthenticationManager` exposed via `AuthenticationConfiguration`. Unused `spring-security-oauth2` legacy starter dropped. `mysql-connector-java` replaced by `com.mysql:mysql-connector-j`.
- Tests on JUnit Jupiter; isolated test profile (H2 in-memory, Cloud Config / Eureka disabled) so `@SpringBootTest` loads context offline; new `JwtUtilTest` covering JJWT 0.12 round-trip and validation.

Closes #4.

> Note: the placeholder HMAC secret in `JwtUtil` is intentionally retained as a TODO marker for issue #6 (Phase 3 Security Hardening), which will externalize and rotate it.

## Test plan
- [x] `./mvnw -B clean test` → BUILD SUCCESS, **5 tests, 0 failures, 0 errors, 0 skipped** (`JwtUtilTest` ×4 + `WotosUserServiceApplicationTests.contextLoads`).
- [x] No remaining `javax.servlet` / `javax.persistence` / `javax.validation` imports.
- [x] No references to Springfox / OpenFeign / `spring-security-oauth2` / Swagger in source (none of those Phase 1 bullets apply to this service).
- [x] Spring Security filter chain logs show `JwtRequestFilter` is inserted before `UsernamePasswordAuthenticationFilter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)