### PR TITLE
Externalize JWT signing secret with fail-fast validation (#6)

### DIFF
--- a/src/main/java/com/wotos/wotosuserservice/security/SecurityConfig.java
+++ b/src/main/java/com/wotos/wotosuserservice/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
  */
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtRequestFilter jwtRequestFilter;

--- a/src/main/java/com/wotos/wotosuserservice/util/JwtUtil.java
+++ b/src/main/java/com/wotos/wotosuserservice/util/JwtUtil.java
@@ -3,6 +3,7 @@ package com.wotos.wotosuserservice.util;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -16,11 +17,25 @@ import java.util.function.Function;
 @Service
 public class JwtUtil {
 
-    // TODO(#6 — Phase 3 Security Hardening): externalize this secret to config and rotate it.
-    // jjwt 0.12 enforces HS256's 256-bit (32-byte) key floor, so the placeholder must stay >= 32 bytes.
-    private static final String SECRET_KEY = "wotos-user-service-development-secret-key-change-in-phase-3";
+    /** HS256 requires a 256-bit (32-byte) key; reject anything weaker at startup. */
+    private static final int MIN_SECRET_BYTES = 32;
 
-    private final SecretKey signingKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    private final SecretKey signingKey;
+    private final long expirationMillis;
+
+    public JwtUtil(
+            @Value("${jwt.secret:}") String secret,
+            @Value("${jwt.expiration-millis:36000000}") long expirationMillis) {
+        byte[] secretBytes = secret == null ? new byte[0] : secret.getBytes(StandardCharsets.UTF_8);
+        if (secretBytes.length < MIN_SECRET_BYTES) {
+            throw new IllegalStateException(
+                    "jwt.secret is missing or shorter than " + MIN_SECRET_BYTES + " bytes. "
+                            + "Provide it via Spring Cloud Config or the JWT_SECRET environment variable; "
+                            + "never commit it to source.");
+        }
+        this.signingKey = Keys.hmacShaKeyFor(secretBytes);
+        this.expirationMillis = expirationMillis;
+    }
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -63,7 +78,7 @@ public class JwtUtil {
                 .claims(claims)
                 .subject(subject)
                 .issuedAt(new Date(nowMillis))
-                .expiration(new Date(nowMillis + 1000 * 60 * 60 * 10))
+                .expiration(new Date(nowMillis + expirationMillis))
                 .signWith(signingKey, Jwts.SIG.HS256)
                 .compact();
     }

--- a/src/test/java/com/wotos/wotosuserservice/util/JwtUtilTest.java
+++ b/src/test/java/com/wotos/wotosuserservice/util/JwtUtilTest.java
@@ -9,15 +9,22 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Round-trip coverage for the jjwt 0.12 migration: a token produced by
- * {@link JwtUtil#generateToken} must verify and parse back with the same signing key.
+ * Round-trip coverage for the jjwt 0.12 migration and the issue #6 secret
+ * externalization: a token produced by {@link JwtUtil#generateToken} must
+ * verify and parse back with the same injected signing key, and the
+ * constructor must reject any secret below the 256-bit HS256 floor.
  */
 class JwtUtilTest {
 
-    private final JwtUtil jwtUtil = new JwtUtil();
+    private static final String TEST_SECRET =
+            "test-secret-key-must-be-at-least-32-bytes-long-for-hs256";
+    private static final long TEST_EXPIRATION_MILLIS = 600_000L;
+
+    private final JwtUtil jwtUtil = new JwtUtil(TEST_SECRET, TEST_EXPIRATION_MILLIS);
 
     private UserDetails user(String username) {
         return new User(username, "password", Collections.emptyList());
@@ -51,6 +58,18 @@ class JwtUtilTest {
         String token = jwtUtil.generateToken(user("tanker"));
 
         assertTrue(jwtUtil.extractExpiration(token).getTime() > System.currentTimeMillis());
+    }
+
+    @Test
+    void constructorRejectsSecretShorterThanTheHs256Floor() {
+        assertThrows(IllegalStateException.class,
+                () -> new JwtUtil("too-short", TEST_EXPIRATION_MILLIS));
+    }
+
+    @Test
+    void constructorRejectsMissingSecret() {
+        assertThrows(IllegalStateException.class,
+                () -> new JwtUtil("", TEST_EXPIRATION_MILLIS));
     }
 
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -17,3 +17,9 @@ spring.cloud.discovery.enabled=false
 eureka.client.enabled=false
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+
+# Test-only JWT secret. The 256-bit floor is enforced by JwtUtil; this value
+# is fixed in the repo deliberately so tests are deterministic and never
+# pull from a developer's real JWT_SECRET env var.
+jwt.secret=test-secret-key-must-be-at-least-32-bytes-long-for-hs256
+jwt.expiration-millis=600000


### PR DESCRIPTION
## Summary
Addresses the **user-service slice** of issue #6 (Phase 3 — Security Hardening).

- `JwtUtil`: hardcoded development secret removed. Constructor now reads `${jwt.secret}` and `${jwt.expiration-millis}` via `@Value`, and throws `IllegalStateException` at startup if the secret is missing or shorter than the HS256 32-byte floor — so no usable signing key can ship from source.
- The real value must come from Spring Cloud Config or the `JWT_SECRET` environment variable. The placeholder uses an empty default (`${jwt.secret:}`) deliberately, so missing config fails loudly instead of silently using a baked-in fallback. No `application.properties` stub is added under `src/main/resources` — that directory is intentionally `.gitignore`d to keep config out of source.
- `SecurityConfig`: `@EnableMethodSecurity` added so this service's future write endpoints can be `@PreAuthorize`-gated. (No write endpoints currently need role enforcement — `/users/login` and `/users/create` are public sign-up flows; `/users/hello` is auth-only.)
- Tests: `JwtUtilTest` constructor-injects a test secret; **two new tests** assert short and missing secrets are rejected at construction. `src/test/resources/application.properties` pins a deterministic test secret + short expiration so `@SpringBootTest` boots without leaking a developer's real `JWT_SECRET`.

### Out of scope
- Cross-service work in #6 (JWT validation filter in `wotos-player-service` / `wotos-statistics-service` / `wotos-vehicle-service`; secret rotation in `wotos-config`) — separate repos / branches.
- Plaintext password storage in `LocalUser` / `Encoder` — not in #6's acceptance criteria, worth its own issue.
- Cosmetic findings in adjacent code (`authrorities` typo, `System.out` → SLF4J) — Phase 6 observability.

> Note: `Closes #6` won't auto-fire when this merges (PR targets `develop`, but the repo's default branch is `master`), so #6 will be closed manually once cross-service follow-ups are also done.

## Test plan
- [x] `./mvnw -B clean test` → BUILD SUCCESS, **7 tests, 0 failures, 0 errors, 0 skipped** (was 5; +1 short-secret, +1 missing-secret).
- [x] Confirmed startup fail-fast: `IllegalStateException` thrown when `jwt.secret` is absent or `< 32` bytes (covered by the two new unit tests).
- [x] `@SpringBootTest` context still loads on the upgraded stack with the externalized config.
- [x] No hardcoded secret remains in `src/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)